### PR TITLE
Bump Selenium.WebDriver from 4.9.1 to 4.11.0

### DIFF
--- a/dotnet-core-webapp.webtests/dotnetcore-webapp.webtests.csproj
+++ b/dotnet-core-webapp.webtests/dotnetcore-webapp.webtests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Selenium.WebDriver" Version="4.9.1" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.11.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="113.0.5672.6300" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumps Selenium.WebDriver from 4.9.1 to 4.11.0.

---
updated-dependencies:
- dependency-name: Selenium.WebDriver dependency-type: direct:production update-type: version-update:semver-minor ...